### PR TITLE
refactor: remove the status field from auth response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+debug*.py
 *.py[cod]
 *$py.class
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tutto-api-client"
-version = "1.0.9"
+version = "1.1.0"
 description = ""
 authors = ["rapha-pereira <raphaelpgomes1@gmail.com>"]
 readme = "README.md"

--- a/tutto_api_client/models/authorization.py
+++ b/tutto_api_client/models/authorization.py
@@ -17,7 +17,6 @@ class _TOKEN_ORIGIN(Enum):
 
 @dataclass(init=True)
 class _Auth:
-    status: int
     message: str
     type: str
     token: str
@@ -91,7 +90,7 @@ class Authorization:
                 },
             )
         )
-        if request["status"] == 200:
+        if request["message"] == "Auth OK":
             return request
 
     @property


### PR DESCRIPTION
- The auth response do not return the status any more.
- So it's removed the field(status) from the _Auth class on models>authorization.py
- And do not check for status 200 any more, now the check is:

```
if request["message"] == "Auth OK":
            return request
```